### PR TITLE
Fix Testing

### DIFF
--- a/lib/Tests.php
+++ b/lib/Tests.php
@@ -71,7 +71,7 @@ abstract class BridgeTest extends PHPUnit_Framework_TestCase {
 	public function defaultTest($datas, $parameters, $minElementCount = -1) {
 
 		$this->assertNotEmpty($datas, "The bridge is returning empty datas");
-		$this->assertGreaterThan($minElementCount, count($datas), "There is not enough elements in the bridge");
+		$this->assertGreaterThanOrEqual($minElementCount, count($datas), "There is not enough elements in the bridge");
 
 		foreach($datas as $row) {
 			if(in_array(self::TEST_TITLE, $parameters)) {

--- a/lib/Tests.php
+++ b/lib/Tests.php
@@ -38,7 +38,8 @@ abstract class BridgeTest extends PHPUnit_Framework_TestCase {
         PHPUnit_Framework_Error_Notice::$enabled = FALSE;
 
 		ini_set('default_socket_timeout', 30);
-
+		
+		BridgeTest::$argNumber = 0;
     }
     
     public function setUp() {

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -4,7 +4,7 @@
 
 		colors="true"
 		bootstrap="../lib/Tests.php"
-		processIsolation="true"
+		processIsolation="false"
         timeoutForSmallTests="1"
         timeoutForMediumTests="1"
         timeoutForLargeTests="6" >


### PR DESCRIPTION
The testing logic works in general, though due to the use of a static variable **$argNumber** the process-isolation option will not work (variable is initialized for each test, not on a class basis). I've changed the implementation slightly to work for now and fixed a logical bug in the assertion routine.